### PR TITLE
🔧 Fix: use getMorphClass

### DIFF
--- a/src/Models/OneTimePassword.php
+++ b/src/Models/OneTimePassword.php
@@ -74,7 +74,7 @@ class OneTimePassword extends Model
     {
         static::query()
             ->where('one_time_passwordable_id', $model->getKey())
-            ->where('one_time_passwordable_type', get_class($model))
+            ->where('one_time_passwordable_type', $model->getMorphClass())
             ->whereNull('used_at')
             ->whereNull('expired_at')
             ->update(['expired_at' => now()]);
@@ -91,7 +91,7 @@ class OneTimePassword extends Model
     ): ?OneTimePassword {
         $query = static::query()
             ->where('one_time_passwordable_id', $model->getKey())
-            ->where('one_time_passwordable_type', get_class($model))
+            ->where('one_time_passwordable_type', $model->getMorphClass())
             ->whereNull('used_at')
             ->whereNull('deleted_at')
             ->orderByDesc('id');

--- a/src/Services/OtpService.php
+++ b/src/Services/OtpService.php
@@ -23,7 +23,7 @@ class OtpService
     {
         $otp = new OneTimePassword();
         $otp->one_time_passwordable_id = $model->getKey();
-        $otp->one_time_passwordable_type = get_class($model);
+        $otp->one_time_passwordable_type = $model->getMorphClass();
 
         $password = app(OtpGenerator::class)->generate($otp);
 

--- a/tests/Fixtures/DummyOtpUser.php
+++ b/tests/Fixtures/DummyOtpUser.php
@@ -13,14 +13,4 @@ class DummyOtpUser extends Model implements OneTimePasswordableInterface
     protected $table = 'otp_users';
     protected $guarded = [];
     public $timestamps = false;
-
-    public function getKey(): int|string|null
-    {
-        return $this->id;
-    }
-
-    public function getMorphClass(): string
-    {
-        return get_class($this);
-    }
 }

--- a/tests/Unit/OtpServiceTest.php
+++ b/tests/Unit/OtpServiceTest.php
@@ -7,6 +7,7 @@ use Blamodex\Otp\Services\OtpService;
 use Blamodex\Otp\Tests\TestCase;
 use Blamodex\Otp\Tests\Fixtures\DummyOtpUser;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class OtpServiceTest extends TestCase
 {
@@ -57,5 +58,31 @@ class OtpServiceTest extends TestCase
 
         $this->assertTrue($otpService->verify($user, $oneTimePassword));
         $this->assertFalse($otpService->verify($user, $oneTimePassword));
+    }
+
+    /**
+     * It returns a password of correct length
+     *
+     * @test
+     */
+    public function test_generate_uses_the_morph_class(): void
+    {
+        $user = DummyOtpUser::create();
+
+        $otpService = new OtpService();
+
+        $otpService->generate($user);
+
+        $this->assertEquals('Blamodex\Otp\Tests\Fixtures\DummyOtpUser', $user->getMorphClass());
+
+        Relation::morphMap([
+            'user' => DummyOtpUser::class,
+        ]);
+
+        $user = DummyOtpUser::create();
+
+        $otpService->generate($user);
+
+        $this->assertEquals('user', $user->getMorphClass());
     }
 }


### PR DESCRIPTION
Description
----
Use the model's `getMorphClass` class instead of `get_class` to avoid morph alias remapping issues

https://laravel.com/docs/12.x/eloquent-relationships#custom-polymorphic-types