### PR TITLE
🔧 Chore: Use morphs in migration and add `oneTimePasswords` relation to trait

### DIFF
--- a/database/migrations/2025_07_04_113000_create_one_time_passwords_table.php
+++ b/database/migrations/2025_07_04_113000_create_one_time_passwords_table.php
@@ -17,8 +17,7 @@ return new class extends Migration
             $table->string('password_hash');
 
             // Polymorphic relationship
-            $table->unsignedBigInteger('one_time_passwordable_id');
-            $table->string('one_time_passwordable_type');
+            $table->morphs('one_time_passwordable');
 
             // Tracking
             $table->dateTime('used_at')->nullable();
@@ -29,7 +28,6 @@ return new class extends Migration
             $table->softDeletes();
 
             // Indexes
-            $table->index(['one_time_passwordable_id', 'one_time_passwordable_type'], 'otp_morph_index');
             $table->index('expired_at');
             $table->index('used_at');
         });

--- a/src/Traits/OneTimePasswordable.php
+++ b/src/Traits/OneTimePasswordable.php
@@ -2,10 +2,17 @@
 
 namespace Blamodex\Otp\Traits;
 
+use Blamodex\Otp\Models\OneTimePassword;
 use Blamodex\Otp\Services\OtpService;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 trait OneTimePasswordable
 {
+    public function oneTimePasswords(): MorphMany
+    {
+        return $this->morphMany(OneTimePassword::class, 'one_time_passwordable');
+    }
+
     /**
      * Generate and store a new password.
      */


### PR DESCRIPTION
Description
----
- Use `morphs` migration helper (flips the columns in the index, otherwise the same)
- Adds `oneTimePasswords` relation to `OneTimePasswordable`