### PR TITLE
🔧 Chore: Separate code coverage command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     },
     "scripts": {
         "test": "phpunit",
+        "test:coverage": "XDEBUG_MODE=coverage phpunit --coverage-html=tests/reports",
         "lint": "phpcs --standard=.phpcs.xml src tests",
         "lint:fix": "phpcbf --standard=.phpcs.xml src tests",
         "analyze": "vendor/bin/phpstan analyse --memory-limit=256M"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,9 +2,6 @@
 <phpunit bootstrap="vendor/autoload.php"
          colors="true"
          stopOnFailure="false">
-    <php>
-        <env name="XDEBUG_MODE" value="coverage"/>
-    </php>
     <testsuites>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
@@ -15,9 +12,4 @@
             <directory>src</directory>
         </include>
     </source>
-    <coverage>
-        <report>
-            <html outputDirectory="tests/reports"/>
-        </report>
-    </coverage>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,7 @@ composer lint:fix
 Check coverage (with Xdebug):
 
 ```bash
-
+composer test:coverage
 ```
 
 ---
@@ -136,6 +136,8 @@ Check coverage (with Xdebug):
 src/
 ├── Models/
 │   └── OneTimePassword.php
+├── Data/
+│   └── OtpData.php
 ├── Services/
 │   ├── OtpGenerator.php
 │   └── OtpService.php


### PR DESCRIPTION
Description
----
Running tests by default ran code coverage reports which can add significant time to test runs. This PR aims to separate running the test suite and running code coverage

run test suite
```shell
composer test
```

run test coverage
```shell
composer test:coverage
```