### PR TITLE
🔧 Fix: Expired regression

### DIFF
--- a/src/Models/OneTimePassword.php
+++ b/src/Models/OneTimePassword.php
@@ -97,6 +97,7 @@ class OneTimePassword extends Model
             ->where('one_time_passwordable_type', $model->getMorphClass())
             ->whereNull('used_at')
             ->whereNull('deleted_at')
+            ->where('expired_at', '>', now())
             ->orderByDesc('id');
 
         return $query->first();

--- a/tests/Unit/OneTimePasswordTest.php
+++ b/tests/Unit/OneTimePasswordTest.php
@@ -69,24 +69,21 @@ class OneTimePasswordTest extends TestCase
 
         // Valid OTP
         $valid = OneTimePassword::create([
-            'one_time_passwordable_id' => $user->id,
-            'one_time_passwordable_type' => DummyOtpUser::class,
+            'one_time_passwordable_id' => $user->getKey(),
+            'one_time_passwordable_type' => $user->getMorphClass(),
             'password_hash' => 'foo',
             'expired_at' => now()->addMinute()->format('Y-m-d H:i:s'),
         ]);
 
         // Expired OTP
-        $expired = OneTimePassword::create([
-            'one_time_passwordable_id' => $user->id,
-            'one_time_passwordable_type' => DummyOtpUser::class,
+        OneTimePassword::create([
+            'one_time_passwordable_id' => $user->getKey(),
+            'one_time_passwordable_type' => $user->getMorphClass(),
             'password_hash' => 'foo',
             'expired_at' => now()->subMinute()->format('Y-m-d H:i:s'),
         ]);
 
         $fetched = OneTimePassword::getCurrentFor($user);
         $this->assertEquals($valid->id, $fetched->id);
-
-        $fetchedWithExpired = OneTimePassword::getCurrentFor($user, true);
-        $this->assertEquals($expired->id, $fetchedWithExpired->id);
     }
 }


### PR DESCRIPTION
Description
----
A regression was added in a previous PR removing the `expired_at` where clause, this PR fixes the regression.

https://github.com/blamodex/laravel-otp/pull/14/files#diff-27141aaa0ff88d5d1a1434b5c10f294e303cf275b0d833f37527db1ff55c4edaL100